### PR TITLE
Improve ApiError display output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes are recorded here. This project follows semantic versioning,
 with one pre-1.0 qualification: a minor release may change generated Rust APIs
 when correcting output that was wrong or incomplete on the wire.
 
+## [Unreleased]
+
+### Fixed
+
+- `ApiError` display output now bounds large response-body previews and includes
+  typed error details or typed-body parse failures when available (#29).
+
 ## [0.7.0] - 2026-07-17
 
 ### Added

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -976,7 +976,9 @@ impl CodeGenerator {
             /// `headers`, and `body` are always populated so callers can
             /// inspect what the server sent without modifying the generated
             /// code. `typed` carries the parsed per-operation error variant
-            /// when the body matched a declared schema.
+            /// when the body matched a declared schema. Formatting the error
+            /// limits only the displayed body preview; the public fields
+            /// retain the complete response and parsing details.
             #[derive(Debug, Clone)]
             pub struct ApiError<E> {
                 pub status: u16,
@@ -984,6 +986,21 @@ impl CodeGenerator {
                 pub body: String,
                 pub typed: Option<E>,
                 pub parse_error: Option<String>,
+            }
+
+            const API_ERROR_BODY_DISPLAY_LIMIT: usize = 500;
+            const API_ERROR_BODY_TRUNCATION_MARKER: &str = "... [truncated]";
+
+            fn display_api_error_body(body: &str) -> std::borrow::Cow<'_, str> {
+                let Some((end, _)) = body.char_indices().nth(API_ERROR_BODY_DISPLAY_LIMIT) else {
+                    return std::borrow::Cow::Borrowed(body);
+                };
+
+                let mut displayed =
+                    String::with_capacity(end + API_ERROR_BODY_TRUNCATION_MARKER.len());
+                displayed.push_str(&body[..end]);
+                displayed.push_str(API_ERROR_BODY_TRUNCATION_MARKER);
+                std::borrow::Cow::Owned(displayed)
             }
 
             impl<E> ApiError<E> {
@@ -1004,7 +1021,22 @@ impl CodeGenerator {
 
             impl<E: std::fmt::Debug> std::fmt::Display for ApiError<E> {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    write!(f, "API error {}: {}", self.status, self.body)
+                    write!(
+                        f,
+                        "API error {}: {}",
+                        self.status,
+                        display_api_error_body(&self.body)
+                    )?;
+
+                    if let Some(typed) = &self.typed {
+                        write!(f, "; typed: {typed:?}")?;
+                    }
+
+                    if let Some(parse_error) = &self.parse_error {
+                        write!(f, "; parse error: {parse_error}")?;
+                    }
+
+                    Ok(())
                 }
             }
 

--- a/src/http_error.rs
+++ b/src/http_error.rs
@@ -212,6 +212,8 @@ pub type HttpResult<T> = Result<T, HttpError>;
 /// inspect what the server actually sent without having to hack the generated
 /// client. `typed` is `Some(_)` when the raw body was successfully parsed into a
 /// per-operation error type; `parse_error` records why parsing failed when not.
+/// Formatting the error limits only the displayed body preview; the public
+/// fields retain the complete response and parsing details.
 #[derive(Debug, Clone)]
 pub struct ApiError<E> {
     pub status: u16,
@@ -219,6 +221,20 @@ pub struct ApiError<E> {
     pub body: String,
     pub typed: Option<E>,
     pub parse_error: Option<String>,
+}
+
+const API_ERROR_BODY_DISPLAY_LIMIT: usize = 500;
+const API_ERROR_BODY_TRUNCATION_MARKER: &str = "... [truncated]";
+
+fn display_api_error_body(body: &str) -> std::borrow::Cow<'_, str> {
+    let Some((end, _)) = body.char_indices().nth(API_ERROR_BODY_DISPLAY_LIMIT) else {
+        return std::borrow::Cow::Borrowed(body);
+    };
+
+    let mut displayed = String::with_capacity(end + API_ERROR_BODY_TRUNCATION_MARKER.len());
+    displayed.push_str(&body[..end]);
+    displayed.push_str(API_ERROR_BODY_TRUNCATION_MARKER);
+    std::borrow::Cow::Owned(displayed)
 }
 
 impl<E> ApiError<E> {
@@ -233,7 +249,22 @@ impl<E> ApiError<E> {
 
 impl<E: std::fmt::Debug> std::fmt::Display for ApiError<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "API error {}: {}", self.status, self.body)
+        write!(
+            f,
+            "API error {}: {}",
+            self.status,
+            display_api_error_body(&self.body)
+        )?;
+
+        if let Some(typed) = &self.typed {
+            write!(f, "; typed: {typed:?}")?;
+        }
+
+        if let Some(parse_error) = &self.parse_error {
+            write!(f, "; parse error: {parse_error}")?;
+        }
+
+        Ok(())
     }
 }
 

--- a/tests/http_error_test.rs
+++ b/tests/http_error_test.rs
@@ -1,4 +1,65 @@
-use openapi_to_rust::http_error::{HttpError, HttpResult};
+use openapi_to_rust::http_error::{ApiError, HttpError, HttpResult};
+use reqwest::header::HeaderMap;
+
+#[derive(Debug)]
+enum TypedApiError {
+    Invalid,
+}
+
+fn api_error<E>(
+    body: impl Into<String>,
+    typed: Option<E>,
+    parse_error: Option<&str>,
+) -> ApiError<E> {
+    ApiError {
+        status: 422,
+        headers: HeaderMap::new(),
+        body: body.into(),
+        typed,
+        parse_error: parse_error.map(str::to_owned),
+    }
+}
+
+#[test]
+fn test_api_error_display_normal_body() {
+    let error = api_error::<TypedApiError>("small response", None, None);
+
+    assert_eq!(error.to_string(), "API error 422: small response");
+}
+
+#[test]
+fn test_api_error_display_truncates_body_without_mutating_it() {
+    let body = "é".repeat(600);
+    let error = api_error::<TypedApiError>(body.clone(), None, None);
+    let displayed = error.to_string();
+
+    assert_eq!(
+        displayed,
+        format!("API error 422: {}... [truncated]", "é".repeat(500))
+    );
+    assert_eq!(error.body, body);
+}
+
+#[test]
+fn test_api_error_display_includes_typed_error() {
+    let error = api_error("validation failed", Some(TypedApiError::Invalid), None);
+
+    assert_eq!(
+        error.to_string(),
+        "API error 422: validation failed; typed: Invalid"
+    );
+}
+
+#[test]
+fn test_api_error_display_includes_parse_error() {
+    let error =
+        api_error::<TypedApiError>("not json", None, Some("expected value at line 1 column 1"));
+
+    assert_eq!(
+        error.to_string(),
+        "API error 422: not json; parse error: expected value at line 1 column 1"
+    );
+}
 
 #[test]
 fn test_http_error_creation() {
@@ -311,6 +372,22 @@ fn test_generated_error_code() {
     assert!(
         client_content.contains("pub fn is_retryable"),
         "Generated code should contain is_retryable method"
+    );
+    assert!(
+        client_content.contains("API_ERROR_BODY_DISPLAY_LIMIT"),
+        "Generated code should bound the displayed API error body"
+    );
+    assert!(
+        client_content.contains("API_ERROR_BODY_TRUNCATION_MARKER"),
+        "Generated code should include a clear body truncation marker"
+    );
+    assert!(
+        client_content.contains("typed: {typed:?}"),
+        "Generated code should display typed API error details"
+    );
+    assert!(
+        client_content.contains("parse error: {parse_error}"),
+        "Generated code should display typed parsing failures"
     );
 
     // Verify HttpResult type alias


### PR DESCRIPTION
## Summary

- cap the displayed raw response body at 500 Unicode characters with a clear truncation marker
- include typed error debug details or the typed-body parse failure when available
- preserve the complete public `body`, `typed`, and `parse_error` fields
- mirror the formatter in generated clients and add focused regression coverage

Closes #29.

## Generated compatibility

- Generated model or method signatures: unchanged
- Query/path/header/body wire behavior: unchanged
- Generated runtime dependencies or features: unchanged
- Configuration defaults or migrations: none
- Remaining unsupported OpenAPI shapes: unchanged

## Validation

- [x] Added focused normal, Unicode truncation, typed, and parse-error tests
- [x] Reviewed generated-code assertions; no snapshots changed
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features`
- [x] Targeted `scripts/spec-compile.sh anthropic openai` generation and compile checks
- [x] Updated rustdoc and the changelog
- [x] Packaging/dependency smoke test is not applicable

## Notes for reviewers

The body cap is character-based, so multibyte UTF-8 responses are never split at an invalid byte boundary. Only the rendered preview is bounded; callers retain the full response body and parsing metadata.

The targeted spec script was run on macOS Bash 3 with an in-memory compatibility replacement for its `mapfile` discovery line; the repository script files were not changed.

This contribution was prepared with assistance from OpenAI Codex. The final diff and validation results were reviewed before submission.