### PR TITLE
chore: release 0.8.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Verify tag matches crate version
         run: |
-          package_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
+          package_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "openapi-to-rust") | .version')"
           test "${GITHUB_REF_NAME}" = "v${package_version}"
       - run: cargo fmt --check
       - run: cargo clippy --all-features -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes are recorded here. This project follows semantic versioning,
 with one pre-1.0 qualification: a minor release may change generated Rust APIs
 when correcting output that was wrong or incomplete on the wire.
 
-## [Unreleased]
+## [0.8.0] - 2026-07-19
+
+### Added
+
+- An in-browser WASM playground at
+  [openapi-to-rust.dev/playground](https://openapi-to-rust.dev/playground):
+  paste a spec or fetch one by URL and get the exact generated file set —
+  byte-identical to `openapi-to-rust generate <SOURCE>` — with a downloadable
+  runnable crate.
+- A default-on `cli` feature gating clap and reqwest. With
+  `--no-default-features` the library compiles on `wasm32-unknown-unknown`;
+  URL policy and spec parsing moved into the shared `spec_source` module.
 
 ### Fixed
 
@@ -94,7 +105,8 @@ when correcting output that was wrong or incomplete on the wire.
   signed enum values, recursive unions, parameter collisions, optional request
   bodies, range response codes, and path-segment encoding.
 
-[Unreleased]: https://github.com/gpu-cli/openapi-to-rust/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/gpu-cli/openapi-to-rust/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/gpu-cli/openapi-to-rust/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/gpu-cli/openapi-to-rust/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/gpu-cli/openapi-to-rust/releases/tag/v0.6.0
 [0.5.3]: https://github.com/gpu-cli/openapi-to-rust/compare/v0.5.2...v0.5.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openapi-to-rust"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "heck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["tmp"]
 
 [package]
 name = "openapi-to-rust"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.88.0"
 autobins = false

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ hosted fixture:
 
 ```bash
 cargo install --locked openapi-to-rust
-openapi-to-rust generate https://raw.githubusercontent.com/gpu-cli/openapi-to-rust/v0.7.0/tests/fixtures/operation_extraction/simple_get.json
+openapi-to-rust generate https://raw.githubusercontent.com/gpu-cli/openapi-to-rust/v0.8.0/tests/fixtures/operation_extraction/simple_get.json
 ```
 
 This writes `src/generated/{types,client,mod}.rs` and the exact dependencies

--- a/website/src/pages/docs/getting-started.astro
+++ b/website/src/pages/docs/getting-started.astro
@@ -6,7 +6,7 @@ const install = `cargo install --locked openapi-to-rust
 openapi-to-rust --version`;
 
 const trial = `openapi-to-rust generate \\
-  https://raw.githubusercontent.com/gpu-cli/openapi-to-rust/v0.7.0/tests/fixtures/operation_extraction/simple_get.json`;
+  https://raw.githubusercontent.com/gpu-cli/openapi-to-rust/v0.8.0/tests/fixtures/operation_extraction/simple_get.json`;
 
 const config = `[generator]
 spec_path = "openapi.yaml"

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -42,7 +42,7 @@ const schemas = [
     downloadUrl: "https://crates.io/crates/openapi-to-rust",
     programmingLanguage: "Rust",
     runtimePlatform: "Rust 1.88 or newer",
-    softwareVersion: "0.7.0",
+    softwareVersion: "0.8.0",
     license: "https://opensource.org/license/mit",
     keywords: "OpenAPI generator Rust, Rust API client generator, Axum server generator, Reqwest codegen",
   },
@@ -94,7 +94,7 @@ const schemas = [
           <a class="button button-primary" href="/playground">Try it in your browser <span aria-hidden="true">→</span></a>
           <a class="button button-secondary" href="/docs/getting-started">Install the CLI <span aria-hidden="true">→</span></a>
         </div>
-        <p class="hero-meta">v0.7.0 · Rust 1.88+ · MIT licensed</p>
+        <p class="hero-meta">v0.8.0 · Rust 1.88+ · MIT licensed</p>
       </div>
 
       <a


### PR DESCRIPTION
Release commit for v0.8.0: version bump in Cargo.toml/Cargo.lock, CHANGELOG cut for 0.8.0 (in-browser WASM playground + default-on `cli` feature; ApiError display fix #29), and version strings in README and the website.

The `v0.8.0` tag points at this commit and drives the crates.io publish + GitHub release via `publish.yml`. Merge to bring the release commit onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)