### PR TITLE
fix - move allOf before the typed shape

### DIFF
--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -154,6 +154,16 @@ pub enum Schema {
         #[serde(flatten)]
         details: SchemaDetails,
     },
+    /// AllOf composition (must come before Typed to handle type + allOf
+    /// patterns)
+    AllOf {
+        #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+        schema_type: Option<SchemaType>,
+        #[serde(rename = "allOf")]
+        all_of: Vec<Schema>,
+        #[serde(flatten)]
+        details: SchemaDetails,
+    },
     /// Schema with `type` as an array (OpenAPI 3.1 / JSON Schema 2020-12).
     /// The canonical 3.1 way to express a nullable type is
     /// `type: ["string", "null"]`. Listed before `Typed` so the array form
@@ -168,13 +178,6 @@ pub enum Schema {
     Typed {
         #[serde(rename = "type")]
         schema_type: SchemaType,
-        #[serde(flatten)]
-        details: SchemaDetails,
-    },
-    /// AllOf composition
-    AllOf {
-        #[serde(rename = "allOf")]
-        all_of: Vec<Schema>,
         #[serde(flatten)]
         details: SchemaDetails,
     },

--- a/src/snapshots/openapi_to_rust__test_helpers__allof_type_object_sibling_test.snap
+++ b/src/snapshots/openapi_to_rust__test_helpers__allof_type_object_sibling_test.snap
@@ -1,0 +1,31 @@
+---
+source: src/test_helpers.rs
+assertion_line: 229
+expression: "&generated_code"
+---
+//! Generated types from OpenAPI specification
+//!
+//! This file contains all the generated types for the API.
+//! Do not edit manually - regenerate using the appropriate script.
+#![allow(clippy::large_enum_variant)]
+#![allow(clippy::format_in_format_args)]
+#![allow(clippy::let_unit_value)]
+#![allow(unreachable_patterns)]
+use serde::{Deserialize, Serialize};
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct Widget {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct WidgetExtra {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct WidgetBase {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+}

--- a/tests/serde_json_value_reduction_tests.rs
+++ b/tests/serde_json_value_reduction_tests.rs
@@ -308,6 +308,48 @@ fn test_nested_allof_composition() {
 }
 
 #[test]
+fn test_allof_with_redundant_type_object_sibling() {
+    // Test AllOf composition that should flatten properties instead of using serde_json::Value
+    // even with type: object.
+    let spec = json!({
+        "openapi": "3.1.0",
+        "info": {"title": "Test", "version": "1.0"},
+        "components": {
+            "schemas": {
+                "Widget": {
+                    "type": "object",
+                    "allOf": [
+                        {"$ref": "#/components/schemas/WidgetBase"},
+                        {"$ref": "#/components/schemas/WidgetExtra"}
+                    ]
+                },
+                "WidgetBase": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"}
+                    }
+                },
+                "WidgetExtra": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"}
+                    }
+                }
+            }
+        }
+    });
+
+    let result =
+        test_generation("allof_type_object_sibling_test", spec).expect("Generation failed");
+
+    assert!(result.contains("pub struct Widget"));
+    // Check different possible formats of string.
+    assert!(result.contains("pub id: Option<String>") || result.contains("pub id: String"));
+    assert!(result.contains("pub name: Option<String>") || result.contains("pub name: String"));
+    assert!(!result.contains("pub type Widget = serde_json::Value"));
+}
+
+#[test]
 fn test_object_with_additional_properties() {
     // Test that objects with additionalProperties correctly use BTreeMap<String, serde_json::Value>
     let spec = json!({

--- a/tests/server_raw_body_roundtrip_test.rs
+++ b/tests/server_raw_body_roundtrip_test.rs
@@ -401,6 +401,21 @@ mod tests {
         }
     }
 
+    fn sample_plugin() -> Plugin {
+        Plugin {
+            added_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+            connection: PluginModeUnion::PluginSupervisedProps(PluginSupervisedProps {}),
+            description: None,
+            id: "plugin-one".to_string(),
+            manifest: PluginManifest::default(),
+            name: "Test Plugin".to_string(),
+            status: PluginStatus::PluginStatusActive(PluginStatusActive {
+                activated_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+            }),
+            version: None,
+        }
+    }
+
     #[async_trait::async_trait]
     impl PluginsApi for Api {
         async fn plugin_update_package(
@@ -412,7 +427,7 @@ mod tests {
             self.captured
                 .send(("plugin".into(), body.map(|value| value.to_vec())))
                 .unwrap();
-            PluginUpdatePackageResponse::Ok(serde_json::json!({"updated": true}))
+            PluginUpdatePackageResponse::Ok(sample_plugin())
         }
     }
 
@@ -437,7 +452,10 @@ mod tests {
             .plugin_update_package("plugin-one", Some(archive.clone()))
             .await
             .unwrap();
-        assert_eq!(response, serde_json::json!({"updated": true}));
+        assert_eq!(
+            serde_json::to_value(&response).unwrap(),
+            serde_json::to_value(sample_plugin()).unwrap()
+        );
         assert_eq!(
             captured_rx.recv().await.unwrap(),
             ("plugin".into(), Some(archive))


### PR DESCRIPTION
## Summary

Fixes #56 by allowing `AllOf` to match `type: object` definitions (even if it is redundant, quite a few public OpenAPI specs do still provide this value), so that the following schema doesn't collapse to `serde_json::Value` because it match `Typed` and not `AllOf`

```yaml
type: object
allOf:
  - ...
  - ...
```


## Generated compatibility

- Generated model or method signatures: Any schema with `type: object` and `allOf` now generate the correct struct instead of becoming `serde_json::Value`
- Query/path/header/body wire behavior: Risks causing issues for those relying on the `Value` type, otherwise not much change.
- Remaining unsupported OpenAPI shapes: The same `type: object` but with with an array `type`  still matches `TypedMulti` before `AllOf` so it still has the same issue. But this PR just brings `AllOf` to the same behaviour as `AnyOf`. (See review notes)

## Validation

- [x] Added or updated a focused fixture and behavioral regression test.
- [x] Reviewed every changed snapshot; no unrelated churn is included.
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Ran `scripts/install-smoke.sh` for packaging/dependency changes.
- [x] Ran a targeted or full `scripts/spec-compile.sh` for generator changes.
- [x] Updated README, rustdoc, or changelog for user-visible behavior.

## Notes for reviewers

The issue in #56 provides a minimal reproducible example, and should be the best to check before/after. I intentionally didn't change `AllOf`/`AnyOf` to accept array `type` (e.g. `type: [object, null]` as the existing code didn't, but I'll likely make an other issue for that.

I had to change one (unrelated) test as it actually required the current behaviour instead of the 'correct' behaviour this PR introduces
